### PR TITLE
Renamed package name in tests and setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import find_packages, setup
 
 README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
 
-packages = find_packages(exclude=['tests*', 'tests', 'cognito/tests*', 'cdu*', 'cdu'])
+packages = find_packages(exclude=['tests*', 'tests', 'warrant/tests*', 'cdu*', 'cdu'])
 
 setup(
-    name='cognito',
+    name='warrant',
     version='0.1',
     packages=packages,
     include_package_data=True,

--- a/warrant/tests/tests.py
+++ b/warrant/tests/tests.py
@@ -118,13 +118,13 @@ class CognitoTestCase(unittest.TestCase):
         self.assertNotEquals(og_acc_token,self.user.access_token)
 
 
-    @patch('cognito.Cognito', autospec=True)
+    @patch('warrant.Cognito', autospec=True)
     def test_validate_verification(self,cognito_user):
         u = cognito_user(self.cognito_user_pool_id,self.app_id,
                      username=self.username)
         u.validate_verification('4321')
 
-    @patch('cognito.Cognito', autospec=True)
+    @patch('warrant.Cognito', autospec=True)
     def test_confirm_forgot_password(self,cognito_user):
         u = cognito_user(self.cognito_user_pool_id, self.app_id,
                          username=self.username)
@@ -154,3 +154,6 @@ class CognitoTestCase(unittest.TestCase):
         )
         self.assertEquals(u.somerandom,'attribute')
 
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`pip install -e warrant`
running tests
```
.....E......E.
======================================================================
ERROR: test_confirm_forgot_password (__main__.CognitoTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/arm/coding/python/cognito/warrant_env/lib/python2.7/site-packages/mock/mock.py", line 1297, in patched
    arg = patching.__enter__()
  File "/home/arm/coding/python/cognito/warrant_env/lib/python2.7/site-packages/mock/mock.py", line 1353, in __enter__
    self.target = self.getter()
  File "/home/arm/coding/python/cognito/warrant_env/lib/python2.7/site-packages/mock/mock.py", line 1523, in <lambda>
    getter = lambda: _importer(target)
  File "/home/arm/coding/python/cognito/warrant_env/lib/python2.7/site-packages/mock/mock.py", line 1206, in _importer
    thing = __import__(import_path)
ImportError: No module named cognito

======================================================================
ERROR: test_validate_verification (__main__.CognitoTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/arm/coding/python/cognito/warrant_env/lib/python2.7/site-packages/mock/mock.py", line 1297, in patched
    arg = patching.__enter__()
  File "/home/arm/coding/python/cognito/warrant_env/lib/python2.7/site-packages/mock/mock.py", line 1353, in __enter__
    self.target = self.getter()
  File "/home/arm/coding/python/cognito/warrant_env/lib/python2.7/site-packages/mock/mock.py", line 1523, in <lambda>
    getter = lambda: _importer(target)
  File "/home/arm/coding/python/cognito/warrant_env/lib/python2.7/site-packages/mock/mock.py", line 1206, in _importer
    thing = __import__(import_path)
ImportError: No module named cognito

----------------------------------------------------------------------
Ran 14 tests in 0.429s
```

```
$ python 
Python 2.7.12 (default, Jan 18 2017, 09:33:51) 
[GCC 4.9.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import cognito
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named cognito
>>> import warrant
>>>
```