### PR TITLE
Add settings for AWS keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,10 @@ you wish local Django users to be created upon successful login. If set to `Fals
 only existing local Django users are updated.  
 Defaults to `True`.
 
+5. Optional - Set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+to the AWS access keys you would like to use.
+Defaults to `None`, which will use the default credentials in your `~/.aws/credentials` file.
+
 #### CognitoBackend Behavior
 Since the username of a Cognito User can never change,
 this is used by the backend to match a Cognito User with a local Django

--- a/cdu/settings.py
+++ b/cdu/settings.py
@@ -52,6 +52,10 @@ COGNITO_ATTR_MAPPING = env(
     },
     var_type='dict')
 
+AWS_ACCESS_KEY_ID = env('AWS_ACCESS_KEY_ID')
+
+AWS_SECRET_ACCESS_KEY = env('AWS_SECRET_ACCESS_KEY')
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/warrant/django/backend.py
+++ b/warrant/django/backend.py
@@ -67,7 +67,10 @@ class AbstractCognitoBackend(ModelBackend):
         :return: returns User instance of AUTH_USER_MODEL or None
         """
         cognito_user = CognitoUser(
-            settings.COGNITO_USER_POOL_ID,settings.COGNITO_APP_ID,
+            settings.COGNITO_USER_POOL_ID,
+            settings.COGNITO_APP_ID,
+            access_key=getattr(settings, 'AWS_ACCESS_KEY_ID', None),
+            secret_key=getattr(settings, 'AWS_SECRET_ACCESS_KEY', None),
             username=username)
         try:
             cognito_user.authenticate(password)
@@ -95,7 +98,7 @@ if DJANGO_VERSION[1] > 10:
     class CognitoBackend(AbstractCognitoBackend):
         def authenticate(self, request, username=None, password=None):
             """
-            Authenticate a Cognito User and store an access, ID and 
+            Authenticate a Cognito User and store an access, ID and
             refresh token in the session.
             """
             user = super(CognitoBackend, self).authenticate(


### PR DESCRIPTION
This PR adds two Django settings: `COGNITO_AWS_ACCESS_KEY_ID` and `COGNITO_AWS_SECRET_ACCESS_KEY`

_This PR looks like I changed a lot of lines because my editor cleans up all trailing whitespace on save._