### PR TITLE
adds enabled field to user response object

### DIFF
--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -392,6 +392,7 @@ class Cognito(object):
                            UserPoolId=self.user_pool_id,
                            Username=self.username)
         user_metadata = {
+            'enabled': user.get('Enabled'),
             'user_status':user.get('UserStatus'),
             'username':user.get('Username'),
             'id_token': self.id_token,


### PR DESCRIPTION
The user object returned from the boto call responds with an "Enabled" value indicating whether or not they're currently disabled or enabled.  This is useful to take advantage of real-time disabling / enabling of users.