### PR TITLE
Consolidate test requirements in file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ python:
   - "2.7"
   - "3.6"
 # command to install dependencies
-install: 
-  - "pip install nose coverage"
-  - "pip install -r requirements.txt"
+install:
+  - "pip install -e '.[test]'"
 # command to run tests
 script: nosetests warrant.tests --nocapture --nologcapture

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 boto3>=1.4.3
 envs>=0.3.0
-mock>=2.0.0
 python-jose>=1.3.2
 requests>=2.13.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,3 @@
+mock>=2.0.0
+nose
+coverage

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup, find_packages
 from pip.req import parse_requirements
 
 install_reqs = parse_requirements('requirements.txt', session=False)
+test_reqs = parse_requirements('requirements_test.txt', session=False)
 
 version = '0.2.0'
 
@@ -26,8 +27,11 @@ setup(
     maintainer='Brian Jinwright',
     packages=find_packages(),
     url='https://github.com/capless/warrant',
-    license='GNU GPL V3',
+    license='Apache License 2.0',
     install_requires=[str(ir.req) for ir in install_reqs],
+    extras_require={
+        'test': [str(ir.req) for ir in test_reqs]
+    },
     include_package_data=True,
     zip_safe=True,
 


### PR DESCRIPTION
Test dependency `mock` was added to `requirements.txt` instead of being part of the test requirements. I also noticed that some of the test requirements only existed in `travis.yml`.

This PR creates a new file `requirements_test.txt` that contains all test requirements. They are referenced from setup.py via an "extras". `travis.yml` has been updated to install the test dependencies via the extras.