### PR TITLE
Fixed wrong line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ pool_region or `boto3` client. Afterwards, the `authenticate_user` class method 
 import boto3
 from warrant.aws_srp import AWSSRP
 
-client = boto3('cognito-idp')
+client = boto3.client('cognito-idp')
 aws = AWSSRP(username='username', password='password', pool_id='user_pool_id',
              client_id='client_id', client=client)
 tokens = aws.authenticate_user()


### PR DESCRIPTION
#43
```python
>>> import boto3
>>> client = boto3('cognito-idp')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'module' object is not callable
```