### PR TITLE
Added support for app clients with a generated secret.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+env:
+  - USE_CLIENT_SECRET=True
+  - USE_CLIENT_SECRET=False
 python:
   - "2.7"
   - "3.6"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ COGNITO_JWKS={"keys": [{"alg": "RS256","e": "AQAB","kid": "123456789ABCDEFGHIJKL
 from warrant import Cognito
 
 u = Cognito('your-user-pool-id','your-client-id',
+    client_secret='optional-client-secret'
     username='optional-username',
     id_token='optional-id-token',
     refresh_token='optional-refresh-token',
@@ -79,6 +80,7 @@ u = Cognito('your-user-pool-id','your-client-id',
 
 - **user_pool_id:** Cognito User Pool ID
 - **client_id:** Cognito User Pool Application client ID
+- **client_secret:** App client secret (if app client is configured with client secret)
 - **username:** User Pool username
 - **id_token:** ID Token returned by authentication
 - **refresh_token:** Refresh Token returned by authentication
@@ -426,8 +428,9 @@ The process involves a series of authentication challenges and responses, which 
 results in a final response that contains ID, access and refresh tokens.
 
 ### Using AWSSRP
-The `AWSSRP` class takes a username, password, cognito user pool id, cognito app id, and an optional
-pool_region or `boto3` client. Afterwards, the `authenticate_user` class method is used for SRP authentication.
+The `AWSSRP` class takes a username, password, cognito user pool id, cognito app id, an optional
+client secret (if app client is configured with client secret), an optional pool_region or `boto3` client.
+Afterwards, the `authenticate_user` class method is used for SRP authentication.
 
 
 ```python

--- a/warrant/aws_srp.py
+++ b/warrant/aws_srp.py
@@ -55,14 +55,14 @@ def pad_hex(long_int):
     :return {String} Padded hex string.
     """
     if not isinstance(long_int, six.string_types):
-        hashStr = long_to_hex(long_int)
+        hash_str = long_to_hex(long_int)
     else:
-        hashStr = long_int
-    if len(hashStr) % 2 == 1:
-        hashStr = '0%s' % hashStr
-    elif hashStr[0] in '89ABCDEFabcdef':
-        hashStr = '00%s' % hashStr
-    return hashStr
+        hash_str = long_int
+    if len(hash_str) % 2 == 1:
+        hash_str = '0%s' % hash_str
+    elif hash_str[0] in '89ABCDEFabcdef':
+        hash_str = '00%s' % hash_str
+    return hash_str
 
 
 def compute_hkdf(ikm, salt):

--- a/warrant/tests/tests.py
+++ b/warrant/tests/tests.py
@@ -10,8 +10,11 @@ from warrant.aws_srp import AWSSRP
 class UserObjTestCase(unittest.TestCase):
 
     def setUp(self):
+        if env('USE_CLIENT_SECRET') == 'True':
+            self.app_id = env('COGNITO_APP_WITH_SECRET_ID')
+        else:
+            self.app_id = env('COGNITO_APP_ID')
         self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID')
-        self.app_id = env('COGNITO_APP_ID')
         self.username = env('COGNITO_TEST_USERNAME')
 
         self.user = Cognito(self.cognito_user_pool_id, self.app_id,
@@ -36,8 +39,11 @@ class UserObjTestCase(unittest.TestCase):
 class GroupObjTestCase(unittest.TestCase):
 
     def setUp(self):
+        if env('USE_CLIENT_SECRET') == 'True':
+            self.app_id = env('COGNITO_APP_WITH_SECRET_ID')
+        else:
+            self.app_id = env('COGNITO_APP_ID')
         self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID')
-        self.app_id = env('COGNITO_APP_ID')
         self.group_data = {'GroupName': 'test_group', 'Precedence': 1}
         self.cognito_obj = Cognito(self.cognito_user_pool_id, self.app_id)
 
@@ -50,9 +56,13 @@ class GroupObjTestCase(unittest.TestCase):
 class CognitoAuthTestCase(unittest.TestCase):
 
     def setUp(self):
+        if env('USE_CLIENT_SECRET') == 'True':
+            self.app_id = env('COGNITO_APP_WITH_SECRET_ID')
+            self.client_secret = env('COGNITO_CLIENT_SECRET')
+        else:
+            self.app_id = env('COGNITO_APP_ID')
+            self.client_secret = None
         self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID')
-        self.app_id = env('COGNITO_APP_ID')
-        self.client_secret = env('COGNITO_CLIENT_SECRET')
         self.username = env('COGNITO_TEST_USERNAME')
         self.password = env('COGNITO_TEST_PASSWORD')
         self.user = Cognito(self.cognito_user_pool_id,self.app_id,
@@ -162,12 +172,15 @@ class CognitoAuthTestCase(unittest.TestCase):
 class AWSSRPTestCase(unittest.TestCase):
 
     def setUp(self):
+        if env('USE_CLIENT_SECRET') == 'True':
+            self.client_secret = env('COGNITO_CLIENT_SECRET')
+            self.app_id = env('COGNITO_APP_WITH_SECRET_ID')
+        else:
+            self.app_id = env('COGNITO_APP_ID')
+            self.client_secret = None
         self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID')
-        self.app_id = env('COGNITO_APP_ID')
-        self.client_secret = env('COGNITO_CLIENT_SECRET')
         self.username = env('COGNITO_TEST_USERNAME')
         self.password = env('COGNITO_TEST_PASSWORD')
-
         self.aws = AWSSRP(username=self.username, password=self.password,
                           pool_id=self.cognito_user_pool_id,
                           client_id=self.app_id, client_secret=self.client_secret)

--- a/warrant/tests/tests.py
+++ b/warrant/tests/tests.py
@@ -52,10 +52,11 @@ class CognitoAuthTestCase(unittest.TestCase):
     def setUp(self):
         self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID')
         self.app_id = env('COGNITO_APP_ID')
+        self.client_secret = env('COGNITO_CLIENT_SECRET')
         self.username = env('COGNITO_TEST_USERNAME')
         self.password = env('COGNITO_TEST_PASSWORD')
         self.user = Cognito(self.cognito_user_pool_id,self.app_id,
-                         username=self.username)
+                         username=self.username, client_secret=self.client_secret)
 
 
     def test_authenticate(self):
@@ -163,12 +164,13 @@ class AWSSRPTestCase(unittest.TestCase):
     def setUp(self):
         self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID')
         self.app_id = env('COGNITO_APP_ID')
+        self.client_secret = env('COGNITO_CLIENT_SECRET')
         self.username = env('COGNITO_TEST_USERNAME')
         self.password = env('COGNITO_TEST_PASSWORD')
 
         self.aws = AWSSRP(username=self.username, password=self.password,
                           pool_id=self.cognito_user_pool_id,
-                          client_id=self.app_id)
+                          client_id=self.app_id, client_secret=self.client_secret)
 
     def tearDown(self):
         del self.aws


### PR DESCRIPTION
#44 
Required env variables for testing:
`COGNITO_APP_WITH_SECRET_ID`
`COGNITO_CLIENT_SECRET`