### PR TITLE
Do not sign requests with boto client

### DIFF
--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -1,5 +1,6 @@
 import ast
 import boto3
+import botocore
 import datetime
 import re
 import requests
@@ -164,6 +165,10 @@ class Cognito(object):
         if access_key and secret_key:
             boto3_client_kwargs['aws_access_key'] = access_key
             boto3_client_kwargs['aws_secret_access_key'] = secret_key
+        else:
+            boto3_client_kwargs['config'] = botocore.config.Config(
+                signature_version=botocore.UNSIGNED
+            )
         if user_pool_region:
             boto3_client_kwargs['region_name'] = user_pool_region
 


### PR DESCRIPTION
Not all requests to Cognito require requests to be signed in. Examples of these are register, authenticate, forgot password, confirm forgot password.

This PR will make sure that request signing is disabled when no auth is passed in. Without this change, botocore will blow up with a `NoCredentialsError` exception:

```
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/warrant/__init__.py", line 289, in authenticate
    tokens = aws.authenticate_user()
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/warrant/aws_srp.py", line 187, in authenticate_user
    ClientId=self.client_id
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/botocore/client.py", line 251, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/botocore/client.py", line 526, in _make_api_call
    operation_model, request_dict)
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/botocore/endpoint.py", line 141, in make_request
    return self._send_request(request_dict, operation_model)
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/botocore/endpoint.py", line 166, in _send_request
    request = self.create_request(request_dict, operation_model)
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/botocore/endpoint.py", line 150, in create_request
    operation_name=operation_model.name)
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/botocore/hooks.py", line 227, in emit
    return self._emit(event_name, kwargs)
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/botocore/hooks.py", line 210, in _emit
    response = handler(**kwargs)
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/botocore/signers.py", line 90, in handler
    return self.sign(operation_name, request)
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/botocore/signers.py", line 147, in sign
    auth.add_auth(request)
  File "/Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/botocore/auth.py", line 316, in add_auth
    raise NoCredentialsError
botocore.exceptions.NoCredentialsError: Unable to locate credentials
```