### PR TITLE
Check if self.base_attributes exists

### DIFF
--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -297,7 +297,10 @@ class Cognito(object):
             }
         }
         """
-        attributes = self.base_attributes.copy()
+        if self.base_attributes is None:
+            attributes = {}
+        else:
+            attributes = self.base_attributes.copy()
         if self.custom_attributes:
             attributes.update(self.custom_attributes)
         cognito_attributes = dict_to_cognito(attributes, attr_map)


### PR DESCRIPTION
`self.base_attributes` is `None` until `add_base_attributes` has been called. This checks the value before calling `.copy()` on it.

Workaround until this fix is merged: call `cognito_obj.add_base_attributes()` to set it to an empty dictionary.