### PR TITLE
Implement resend confirmation code method

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Makes working with AWS Cognito easier for Python developers.
         - [Confirm Forgot Password](#confirm-forgot-password)
         - [Change Password](#change-password)
         - [Confirm Sign Up](#confirm-sign-up)
+        - [Resend Confirmation Code](#resend-confirmation-code)
         - [Update Profile](#update-profile)
         - [Send Verification](#send-verification)
         - [Get User Object](#get-user-object)
@@ -262,6 +263,18 @@ from warrant import Cognito
 u = Cognito('your-user-pool-id','your-client-id')
 
 u.confirm_sign_up('users-conf-code',username='bob')
+```
+
+#### Resend Confirmation Code
+
+Resend the confirmation for registration
+
+```python
+from warrant import Cognito
+
+u = Cognito('your-user-pool-id','your-client-id')
+
+u.resend_confirmation_code(username='bob')
 ```
 
 ##### Arguments

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -338,10 +338,8 @@ class Cognito(object):
         :param username: User's username
         :return:
         """
-        if not username:
-            username = self.username
         params = {'ClientId': self.client_id,
-                  'Username': username,
+                  'Username': self.username if username is None else username,
                   'ConfirmationCode': confirmation_code}
         self._add_secret_hash(params, 'SecretHash')
         self.client.confirm_sign_up(**params)
@@ -351,10 +349,8 @@ class Cognito(object):
         Resend the confirmation for registration
         :param username: User's username
         """
-        if not username:
-            username = self.username
         params = {'ClientId': self.client_id,
-                  'Username': username}
+                  'Username': self.username if username is None else username}
         self._add_secret_hash(params, 'SecretHash')
         self.client.resend_confirmation_code(**params)
 

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -346,6 +346,18 @@ class Cognito(object):
         self._add_secret_hash(params, 'SecretHash')
         self.client.confirm_sign_up(**params)
 
+    def resend_confirmation_code(self,username=None):
+        """
+        Resend the confirmation for registration
+        :param username: User's username
+        """
+        if not username:
+            username = self.username
+        params = {'ClientId': self.client_id,
+                  'Username': username}
+        self._add_secret_hash(params, 'SecretHash')
+        self.client.resend_confirmation_code(**params)
+
     def admin_authenticate(self, password):
         """
         Authenticate the user using admin super privileges

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -268,11 +268,11 @@ class Cognito(object):
     def add_custom_attributes(self, **kwargs):
         custom_key = 'custom'
         custom_attributes = {}
-        
+
         for old_key, value in kwargs.items():
             new_key = custom_key + ':' + old_key
             custom_attributes[new_key] = value
-        
+
         self.custom_attributes = custom_attributes
 
     def register(self, username, password, attr_map=None):

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -330,7 +330,7 @@ class Cognito(object):
             Username=username,
         )
 
-    def confirm_sign_up(self,confirmation_code,username=None):
+    def confirm_sign_up(self, confirmation_code, username=None):
         """
         Using the confirmation code that is either sent via email or text
         message.
@@ -346,7 +346,7 @@ class Cognito(object):
         self._add_secret_hash(params, 'SecretHash')
         self.client.confirm_sign_up(**params)
 
-    def resend_confirmation_code(self,username=None):
+    def resend_confirmation_code(self, username=None):
         """
         Resend the confirmation for registration
         :param username: User's username


### PR DESCRIPTION
Added a new function `resend_confirmation_code` to Cognito object, which accept username as argument to trigger resend confirmation code.

I noted that there's no tests for confirmation. So I didn't add any.

I would like to make other changes if needed.