### PR TITLE
Added Support for non en_US locale

### DIFF
--- a/warrant/aws_srp.py
+++ b/warrant/aws_srp.py
@@ -8,6 +8,7 @@ import re
 import boto3
 import os
 import six
+from babel.dates import format_datetime
 
 from .exceptions import ForceChangePasswordException
 
@@ -178,8 +179,10 @@ class AWSSRP(object):
         srp_b_hex = challenge_parameters['SRP_B']
         secret_block_b64 = challenge_parameters['SECRET_BLOCK']
         # re strips leading zero from a day number (required by AWS Cognito)
-        timestamp = re.sub(r" 0(\d) ", r" \1 ",
-                           datetime.datetime.utcnow().strftime("%a %b %d %H:%M:%S UTC %Y"))
+        timestamp = re.sub(r" 0(\d) ", r" \1 ", 
+                           format_datetime(datetime.datetime.utcnow(), 
+                                           "EEE MMM d HH:mm:ss UTC yyyy", 
+                                           locale='en'))
         hkdf = self.get_password_authentication_key(user_id_for_srp,
                                                     self.password, hex_to_long(srp_b_hex), salt_hex)
         secret_block_bytes = base64.standard_b64decode(secret_block_b64)


### PR DESCRIPTION
If the underlying OS has it's locale set to something different than en_* then the authentication code may break because AWS is expecting the day of week in english.

I found this issue while integrating warrant with a pyQT based application on a system with de_DE locale. The day of week was transmitted as Do instead Thu and caused the exception: 
InvalidParameterException: TIMESTAMP format should be EEE MMM d HH:mm:ss z yyyy in english. 

This modification would introduce babel.dates as additional dependency. 