### PR TITLE
Add support for custom validation in pre-sign up trigger

### DIFF
--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -275,7 +275,7 @@ class Cognito(object):
         
         self.custom_attributes = custom_attributes
 
-    def register(self, username, password, attr_map=None):
+    def register(self, username, password, attr_map=None, validation_data=None):
         """
         Register the user. Other base attributes from AWS Cognito User Pools
         are  address, birthdate, email, family_name (last name), gender,
@@ -285,6 +285,7 @@ class Cognito(object):
         :param username: User Pool username
         :param password: User Pool password
         :param attr_map: Attribute map to Cognito's attributes
+        :param validation_data: Validation data dict for custom validation in pre-sign up trigger
         :return response: Response from Cognito
 
         Example response::
@@ -307,6 +308,10 @@ class Cognito(object):
             'Password': password,
             'UserAttributes': cognito_attributes
         }
+        if validation_data:
+            cognito_validation_data = dict_to_cognito(validation_data)
+            params.update({'ValidationData': cognito_validation_data})
+
         self._add_secret_hash(params, 'SecretHash')
         response = self.client.sign_up(**params)
 


### PR DESCRIPTION
This PR adds an optional kwarg to `Cognito.register` to support passing custom validation data to Cognito for use in a pre-sign up lambda trigger.

Boto3 `sign_up` documentation: http://boto3.readthedocs.io/en/latest/reference/services/cognito-idp.html#CognitoIdentityProvider.Client.sign_up

AWS pre sign-up documentation: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-lambda-trigger-syntax-pre-signup.html