### PR TITLE
Cognito region not being set correctly.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pip.req import parse_requirements
 install_reqs = parse_requirements('requirements.txt', session=False)
 test_reqs = parse_requirements('requirements_test.txt', session=False)
 
-version = '0.6.1'
+version = '0.6.2'
 
 README="""Python class to integrate Boto3's Cognito client so it is easy to login users. With SRP support."""
 

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -166,8 +166,8 @@ class Cognito(object):
         if access_key and secret_key:
             boto3_client_kwargs['aws_access_key_id'] = access_key
             boto3_client_kwargs['aws_secret_access_key'] = secret_key
-        if user_pool_region:
-            boto3_client_kwargs['region_name'] = user_pool_region
+        if self.user_pool_region:
+            boto3_client_kwargs['region_name'] = self.user_pool_region
 
         self.client = boto3.client('cognito-idp', **boto3_client_kwargs)
 


### PR DESCRIPTION
### Problem
We are using EC2 role profiles to run warrant + cognito via [Django-Warrant](https://github.com/MetaMetricsInc/django-warrant).

There is an issue where the region isn't being set even after the COGNITO_USER_POOL_ID is set. This results in a stacktrace:
```
 File "/usr/local/lib/python3.5/dist-packages/django_warrant/backend.py", line 79, in authenticate
    username=username)
  File "/usr/local/lib/python3.5/dist-packages/warrant/__init__.py", line 179, in __init__
    self.client = boto3.client('cognito-idp', **boto3_client_kwargs)
  File "/usr/local/lib/python3.5/dist-packages/boto3/__init__.py", line 83, in client
    return _get_default_session().client(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/boto3/session.py", line 263, in client
    aws_session_token=aws_session_token, config=config)
  File "/usr/local/lib/python3.5/dist-packages/botocore/session.py", line 861, in create_client
    client_config=config, api_version=api_version)
  File "/usr/local/lib/python3.5/dist-packages/botocore/client.py", line 76, in create_client
    verify, credentials, scoped_config, client_config, endpoint_bridge)
  File "/usr/local/lib/python3.5/dist-packages/botocore/client.py", line 295, in _get_client_args
    verify, credentials, scoped_config, client_config, endpoint_bridge)
  File "/usr/local/lib/python3.5/dist-packages/botocore/args.py", line 45, in get_client_args
    endpoint_url, is_secure, scoped_config)
  File "/usr/local/lib/python3.5/dist-packages/botocore/args.py", line 111, in compute_client_args
    service_name, region_name, endpoint_url, is_secure)
  File "/usr/local/lib/python3.5/dist-packages/botocore/client.py", line 368, in resolve
    service_name, region_name)
  File "/usr/local/lib/python3.5/dist-packages/botocore/regions.py", line 122, in construct_endpoint
    partition, service_name, region_name)
  File "/usr/local/lib/python3.5/dist-packages/botocore/regions.py", line 135, in _endpoint_for_partition
    raise NoRegionError()
botocore.exceptions.NoRegionError: You must specify a region.
```

Warrant is doing this but calling the wrong variables.

### Fix
This PR simple points Warrant to use the correct variable so the kwargs passed to boto are correct.