### PR TITLE
Modify get_users to return all users in the user pool instead of just the first 60 

### DIFF
--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -463,8 +463,9 @@ class Cognito(object):
         """
         Returns all users for a user pool. Returns instances of the
         self.user_class.
-        :param attr_map:
-        :return:
+        :param attr_map: Dictionary map from Cognito attributes to attribute
+        names we would like to show to our users
+        :return: list of self.user_class
         """
         response = self.client.list_users(UserPoolId=self.user_pool_id)
         user_list = response.get("Users")

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -466,14 +466,23 @@ class Cognito(object):
         :param attr_map:
         :return:
         """
-        kwargs = {"UserPoolId":self.user_pool_id}
+        response = self.client.list_users(UserPoolId=self.user_pool_id)
+        user_list = response.get("Users")
+        page_token = response.get("PaginationToken")
+        
+        while page_token:
+            response = self.client.list_users(
+                UserPoolId=self.user_pool_id, 
+                PaginationToken=page_token
+            )
+            user_list.extend(response.get("Users"))
+            page_token = response.get("PaginationToken")
 
-        response = self.client.list_users(**kwargs)
         return [self.get_user_obj(user.get('Username'),
                                   attribute_list=user.get('Attributes'),
                                   metadata={'username':user.get('Username')},
                                   attr_map=attr_map)
-                for user in response.get('Users')]
+                for user in user_list]
 
     def admin_get_user(self, attr_map=None):
         """


### PR DESCRIPTION
get_users currently advertises that it returns all users but in fact it only returns the first 60 due to the fact that cognito list_users paginates after 60 users. I've changed it to pull all the users using the page token.

This seems reasonable to me but given this list could be huge, it may be worth passing the page token back to the caller to allow them to pull each page themselves. Any thoughts?