### PR TITLE
README.md: document AWSSRP.set_new_password_challenge()

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Makes working with AWS Cognito easier for Python developers.
         - [Logout](#logout)
 - [Cognito SRP Utility](#cognito-srp-utility) `warrant.aws_srp.AWSSRP`
     - [Using AWSSRP](#using-awssrp)
+    - [Setting new password with AWSSRP](#setting-new-password-with-awssrp)
 - [Projects Using Warrant](#projects-using-warrant)
     - [Django Warrant](#django-warrant)
 - [Authors](#authors)
@@ -458,6 +459,30 @@ client = boto3.client('cognito-idp')
 aws = AWSSRP(username='username', password='password', pool_id='user_pool_id',
              client_id='client_id', client=client)
 tokens = aws.authenticate_user()
+```
+
+### Setting new password with AWSSRP
+
+If you try to change the password with the `Cognito.change_password()` you
+might come across following error:
+
+```
+  File ".../warrant/__init__.py", line 196, in check_token
+    raise AttributeError('Access Token Required to Check Token')
+AttributeError: Access Token Required to Check Token
+```
+
+which was asked for in a number of issues. The correct approach is to use
+`AWSSRP.set_new_password_challenge()` as shown below:
+
+```python
+import boto3
+from warrant.aws_srp import AWSSRP
+
+client = boto3.client('cognito-idp', region_name='region')
+aws = AWSSRP(username='username', password='password', pool_id='user_pool_id',
+             client_id='client_id', client=client)
+tokens = aws.set_new_password_challenge('new_password')
 ```
 
 ## Projects Using Warrant


### PR DESCRIPTION
This problem was raised in a number of issues such as this one:
https://github.com/capless/warrant/issues/29

The `set_new_password_challenge()` was introduced in the:
https://github.com/capless/warrant/pull/25 and is not yet documented.

This should help the newcomers to get started with this module.

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>

I'm far from Cognito / Python expert - just wanted to quickly test something and stumbled upon
following error. Found the solution hidden in the issues and code of this merge request, so
decided to add it to README.  Let me know if you think this is fine. Thanks!