### PR TITLE
Changed 'add_base_attribute' method name into 'set_base_attribute'

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ u = Cognito('your-user-pool-id','your-client-id',
 
 Register a user to the user pool
 
-**Important:** The arguments for `add_base_attributes` and `add_custom_attributes` methods depend on your user pool's configuration, and make sure the client id (app id) used has write permissions for the attriubtes you are trying to create. Example, if you want to create a user with a given_name equal to Johnson make sure the client_id you're using has permissions to edit or create given_name for a user in the pool.
+**Important:** The arguments for `set_base_attributes` and `add_custom_attributes` methods depend on your user pool's configuration, and make sure the client id (app id) used has write permissions for the attriubtes you are trying to create. Example, if you want to create a user with a given_name equal to Johnson make sure the client_id you're using has permissions to edit or create given_name for a user in the pool.
 
 
 ```python
@@ -137,7 +137,7 @@ from warrant import Cognito
 
 u = Cognito('your-user-pool-id', 'your-client-id')
 
-u.add_base_attributes(email='you@you.com', some_random_attr='random value')
+u.set_base_attributes(email='you@you.com', some_random_attr='random value')
 
 u.register('username', 'password')
 ```
@@ -151,7 +151,7 @@ from warrant import Cognito
 
 u = Cognito('your-user-pool-id', 'your-client-id')
 
-u.add_base_attributes(email='you@you.com', some_random_attr='random value')
+u.set_base_attributes(email='you@you.com', some_random_attr='random value')
 
 u.add_custom_attributes(state='virginia', city='Centreville')
 

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -262,7 +262,7 @@ class Cognito(object):
             expired = False
         return expired
 
-    def add_base_attributes(self, **kwargs):
+    def set_base_attributes(self, **kwargs):
         self.base_attributes = kwargs
 
     def add_custom_attributes(self, **kwargs):

--- a/warrant/tests/tests.py
+++ b/warrant/tests/tests.py
@@ -93,14 +93,17 @@ class CognitoAuthTestCase(unittest.TestCase):
     def test_register(self, cognito_user):
         u = cognito_user(self.cognito_user_pool_id, self.app_id,
                          username=self.username)
-        u.add_base_attributes(
+        base_attr = dict(
             given_name='Brian', family_name='Jones',
             name='Brian Jones', email='bjones39@capless.io',
             phone_number='+19194894555', gender='Male',
-            preferred_username='billyocean')
+            preferred_username='billyocean'
+        )
+
+        u.set_base_attributes(**base_attr)
         res = u.register('sampleuser', 'sample4#Password')
 
-        #TODO: Write assumptions
+        self.assertEqual(res, base_attr)
 
 
     def test_renew_tokens(self):


### PR DESCRIPTION
This PR addresses GH-117 by refactoring the method name `add_base_attribute` to `set_base_attribute` 

Prior to this change, the `add_base_attribute` had an idempotent definition : 

` self.base_attributes = kwargs` 

While the method declaration let's the user think that this method is indeed not idempotent by having the keyword `add` in the method declaration. Setting it to `set_base_attribute` will remove potential errors from users.