### PR TITLE
Fix setup install for py37

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
 import os
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+
+try:
+    from pip._internal.req import parse_requirements
+except ImportError:
+    from pip.req import parse_requirements
 
 install_reqs = parse_requirements('requirements.txt', session=False)
 test_reqs = parse_requirements('requirements_test.txt', session=False)


### PR DESCRIPTION
This PR brings compatibility to install the package using **Python 3.7**. Without this, trying to call the `pip install -e .` command will result in : 

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/user/workspace/warrant/setup.py", line 4, in <module>
    from pip.req import parse_requirements
ModuleNotFoundError: No module named 'pip.req'
```

It seems that with the release of `pip>=10.0` some breaking changes were introduced in the API. This was tested with Python `3.7`, Python `3.5` and Python `2.7`. This should fix GH-116 as well.