### PR TITLE
added user_poor_region parameter to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ u = Cognito('your-user-pool-id','your-client-id',
     refresh_token='optional-refresh-token',
     access_token='optional-access-token',
     access_key='optional-access-key',
-    secret_key='optional-secret-key')
+    secret_key='optional-secret-key',
+    user_pool_region='optional-user-pool-region')
 ```
 
 #### Arguments
@@ -87,7 +88,7 @@ u = Cognito('your-user-pool-id','your-client-id',
 - **access_token:** Access Token returned by authentication
 - **access_key:** AWS IAM access key
 - **secret_key:** AWS IAM secret key
-
+- **user_poor_region:** Region Cognito User Pool is hosted in
 
 ### Examples with Realistic Arguments ###
 


### PR DESCRIPTION
added user_poor_region parameter to the Cognito invocation in the example with all arguments. The argument exists in __init__.py but not mentioned.