### PR TITLE
Add encoded data to pertinent Cognito boto calls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pip.req import parse_requirements
 install_reqs = parse_requirements('requirements.txt', session=False)
 test_reqs = parse_requirements('requirements_test.txt', session=False)
 
-version = '0.6.1'
+version = '0.6.2'
 
 README="""Python class to integrate Boto3's Cognito client so it is easy to login users. With SRP support."""
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 import os
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 install_reqs = parse_requirements('requirements.txt', session=False)
 test_reqs = parse_requirements('requirements_test.txt', session=False)

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -137,7 +137,7 @@ class Cognito(object):
             self, user_pool_id, client_id,user_pool_region=None,
             username=None, id_token=None, refresh_token=None,
             access_token=None, client_secret=None,
-            access_key=None, secret_key=None,
+            access_key=None, secret_key=None, user_context_data=None
             ):
         """
         :param user_pool_id: Cognito User Pool ID
@@ -158,6 +158,7 @@ class Cognito(object):
         self.access_token = access_token
         self.refresh_token = refresh_token
         self.client_secret = client_secret
+        self.user_context_data = user_context_data
         self.token_type = None
         self.custom_attributes = None
         self.base_attributes = None
@@ -268,11 +269,11 @@ class Cognito(object):
     def add_custom_attributes(self, **kwargs):
         custom_key = 'custom'
         custom_attributes = {}
-        
+
         for old_key, value in kwargs.items():
             new_key = custom_key + ':' + old_key
             custom_attributes[new_key] = value
-        
+
         self.custom_attributes = custom_attributes
 
     def register(self, username, password, attr_map=None):
@@ -551,6 +552,7 @@ class Cognito(object):
         self._add_secret_hash(auth_params, 'SECRET_HASH')
         refresh_response = self.client.initiate_auth(
             ClientId=self.client_id,
+            UserContextData=user_context_data,
             AuthFlow='REFRESH_TOKEN',
             AuthParameters=auth_params,
         )
@@ -570,6 +572,7 @@ class Cognito(object):
         """
         params = {
             'ClientId': self.client_id,
+            'UserContextData': self.user_context_data,
             'Username': self.username
         }
         self._add_secret_hash(params, 'SecretHash')
@@ -598,6 +601,7 @@ class Cognito(object):
         :param password: New password
         """
         params = {'ClientId': self.client_id,
+                  'UserContextData': self.user_context_data
                   'Username': self.username,
                   'ConfirmationCode': confirmation_code,
                   'Password': password

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -137,7 +137,7 @@ class Cognito(object):
             self, user_pool_id, client_id,user_pool_region=None,
             username=None, id_token=None, refresh_token=None,
             access_token=None, client_secret=None,
-            access_key=None, secret_key=None, user_context_data=None
+            access_key=None, secret_key=None, user_context_data={}
             ):
         """
         :param user_pool_id: Cognito User Pool ID

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -601,7 +601,7 @@ class Cognito(object):
         :param password: New password
         """
         params = {'ClientId': self.client_id,
-                  'UserContextData': self.user_context_data
+                  'UserContextData': self.user_context_data,
                   'Username': self.username,
                   'ConfirmationCode': confirmation_code,
                   'Password': password

--- a/warrant/aws_srp.py
+++ b/warrant/aws_srp.py
@@ -197,13 +197,14 @@ class AWSSRP(object):
                 self.get_secret_hash(self.username, self.client_id, self.client_secret)})
         return response
 
-    def authenticate_user(self, client=None):
+    def authenticate_user(self, client=None, user_context_data=None):
         boto_client = self.client or client
         auth_params = self.get_auth_params()
         response = boto_client.initiate_auth(
             AuthFlow='USER_SRP_AUTH',
             AuthParameters=auth_params,
-            ClientId=self.client_id
+            ClientId=(client or self.client_id),
+            UserContextData=user_context_data
         )
         if response['ChallengeName'] == self.PASSWORD_VERIFIER_CHALLENGE:
             challenge_response = self.process_challenge(response['ChallengeParameters'])
@@ -219,13 +220,14 @@ class AWSSRP(object):
         else:
             raise NotImplementedError('The %s challenge is not supported' % response['ChallengeName'])
 
-    def set_new_password_challenge(self, new_password, client=None):
+    def set_new_password_challenge(self, new_password, client=None, user_context_data=None):
         boto_client = self.client or client
         auth_params = self.get_auth_params()
         response = boto_client.initiate_auth(
             AuthFlow='USER_SRP_AUTH',
             AuthParameters=auth_params,
-            ClientId=self.client_id
+            ClientId=(client or self.client_id),
+            UserContextData=user_context_data
         )
         if response['ChallengeName'] == self.PASSWORD_VERIFIER_CHALLENGE:
             challenge_response = self.process_challenge(response['ChallengeParameters'])

--- a/warrant/aws_srp.py
+++ b/warrant/aws_srp.py
@@ -212,7 +212,9 @@ class AWSSRP(object):
             tokens = boto_client.respond_to_auth_challenge(
                 ClientId=self.client_id,
                 ChallengeName=self.PASSWORD_VERIFIER_CHALLENGE,
-                ChallengeResponses=challenge_response)
+                ChallengeResponses=challenge_response,
+                UserContextData=self.user_context_data
+            )
 
             if tokens.get('ChallengeName') == self.NEW_PASSWORD_REQUIRED_CHALLENGE:
                 raise ForceChangePasswordException('Change password before authenticating')
@@ -235,7 +237,9 @@ class AWSSRP(object):
             tokens = boto_client.respond_to_auth_challenge(
                 ClientId=self.client_id,
                 ChallengeName=self.PASSWORD_VERIFIER_CHALLENGE,
-                ChallengeResponses=challenge_response)
+                ChallengeResponses=challenge_response,
+                UserContextData=self.user_context_data
+            )
 
             if tokens['ChallengeName'] == self.NEW_PASSWORD_REQUIRED_CHALLENGE:
                 challenge_response = {
@@ -246,7 +250,9 @@ class AWSSRP(object):
                     ClientId=self.client_id,
                     ChallengeName=self.NEW_PASSWORD_REQUIRED_CHALLENGE,
                     Session=tokens['Session'],
-                    ChallengeResponses=challenge_response)
+                    ChallengeResponses=challenge_response,
+                    UserContextData=self.user_context_data
+                )
                 return new_password_response
             return tokens
         else:

--- a/warrant/aws_srp.py
+++ b/warrant/aws_srp.py
@@ -201,6 +201,9 @@ class AWSSRP(object):
     def authenticate_user(self, client=None):
         boto_client = self.client or client
         auth_params = self.get_auth_params()
+
+        print('USER_CONTEXT: {0}'.format(self.user_context_data))
+
         response = boto_client.initiate_auth(
             AuthFlow='USER_SRP_AUTH',
             AuthParameters=auth_params,

--- a/warrant/aws_srp.py
+++ b/warrant/aws_srp.py
@@ -200,7 +200,7 @@ class AWSSRP(object):
 
     def authenticate_user(self, client=None, user_context_data=None):
         boto_client = self.client or client
-        user_context_data = self.user_context_data or user_context_dataå
+        user_context_data = self.user_context_data or user_context_data
         auth_params = self.get_auth_params()
 
         print('USER_CONTEXT: {0}'.format(user_context_data))

--- a/warrant/aws_srp.py
+++ b/warrant/aws_srp.py
@@ -198,17 +198,18 @@ class AWSSRP(object):
                 self.get_secret_hash(self.username, self.client_id, self.client_secret)})
         return response
 
-    def authenticate_user(self, client=None):
+    def authenticate_user(self, client=None, user_context_data=None):
         boto_client = self.client or client
+        user_context_data = self.user_context_data or user_context_dataå
         auth_params = self.get_auth_params()
 
-        print('USER_CONTEXT: {0}'.format(self.user_context_data))
+        print('USER_CONTEXT: {0}'.format(user_context_data))
 
         response = boto_client.initiate_auth(
             AuthFlow='USER_SRP_AUTH',
             AuthParameters=auth_params,
             ClientId=(client or self.client_id),
-            UserContextData=self.user_context_data
+            UserContextData=user_context_data
         )
         if response['ChallengeName'] == self.PASSWORD_VERIFIER_CHALLENGE:
             challenge_response = self.process_challenge(response['ChallengeParameters'])
@@ -216,7 +217,7 @@ class AWSSRP(object):
                 ClientId=self.client_id,
                 ChallengeName=self.PASSWORD_VERIFIER_CHALLENGE,
                 ChallengeResponses=challenge_response,
-                UserContextData=self.user_context_data
+                UserContextData=user_context_data
             )
 
             if tokens.get('ChallengeName') == self.NEW_PASSWORD_REQUIRED_CHALLENGE:

--- a/warrant/aws_srp.py
+++ b/warrant/aws_srp.py
@@ -197,7 +197,7 @@ class AWSSRP(object):
                 self.get_secret_hash(self.username, self.client_id, self.client_secret)})
         return response
 
-    def authenticate_user(self, client=None, user_context_data=None):
+    def authenticate_user(self, client=None, user_context_data={}):
         boto_client = self.client or client
         auth_params = self.get_auth_params()
         response = boto_client.initiate_auth(
@@ -220,7 +220,7 @@ class AWSSRP(object):
         else:
             raise NotImplementedError('The %s challenge is not supported' % response['ChallengeName'])
 
-    def set_new_password_challenge(self, new_password, client=None, user_context_data=None):
+    def set_new_password_challenge(self, new_password, client=None, user_context_data={}):
         boto_client = self.client or client
         auth_params = self.get_auth_params()
         response = boto_client.initiate_auth(

--- a/warrant/aws_srp.py
+++ b/warrant/aws_srp.py
@@ -261,6 +261,7 @@ class AWSSRP(object):
         auth_params = self.get_auth_params()
 
         response = boto_client.admin_initiate_auth(
+            UserPoolId=self.pool_id,
             AuthFlow='USER_SRP_AUTH',
             AuthParameters=auth_params,
             ClientId=(client or self.client_id),
@@ -269,6 +270,7 @@ class AWSSRP(object):
         if response['ChallengeName'] == self.PASSWORD_VERIFIER_CHALLENGE:
             challenge_response = self.process_challenge(response['ChallengeParameters'])
             tokens = boto_client.admin_respond_to_auth_challenge(
+                UserPoolId=self.pool_id,
                 ClientId=self.client_id,
                 ChallengeName=self.PASSWORD_VERIFIER_CHALLENGE,
                 ChallengeResponses=challenge_response,
@@ -281,6 +283,7 @@ class AWSSRP(object):
                     'NEW_PASSWORD': new_password
                 }
                 new_password_response = boto_client.admin_respond_to_auth_challenge(
+                    UserPoolId=self.pool_id,
                     ClientId=self.client_id,
                     ChallengeName=self.NEW_PASSWORD_REQUIRED_CHALLENGE,
                     Session=tokens['Session'],

--- a/warrant/aws_srp.py
+++ b/warrant/aws_srp.py
@@ -211,6 +211,7 @@ class AWSSRP(object):
             ClientId=(client or self.client_id),
             UserContextData=user_context_data
         )
+        print('AUTH_RESPONSE: {0}'.format(response))
         if response['ChallengeName'] == self.PASSWORD_VERIFIER_CHALLENGE:
             challenge_response = self.process_challenge(response['ChallengeParameters'])
             tokens = boto_client.respond_to_auth_challenge(
@@ -219,6 +220,8 @@ class AWSSRP(object):
                 ChallengeResponses=challenge_response,
                 UserContextData=user_context_data
             )
+
+            print('AUTH_TOKENS: {0}'.format(tokens))
 
             if tokens.get('ChallengeName') == self.NEW_PASSWORD_REQUIRED_CHALLENGE:
                 raise ForceChangePasswordException('Change password before authenticating')


### PR DESCRIPTION
In order to log the correct info in lambda for security events, User Context Data needs to be able to be passed in.