### PR TITLE
Switch to python-jose

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ boto3~=1.10.49
 envs~=1.3
 python-jose[pycryptodome]~=3.1.0
 requests~=2.22.0
-six~=1.13.0
+six>=1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-boto3>=1.4.3
-envs>=0.3.0
-python-jose-cryptodome>=1.3.2
-requests>=2.13.0
+boto3~=1.10.49
+envs~=1.3
+python-jose[pycryptodome]~=3.1.0
+requests~=2.22.0
+six~=1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-boto3~=1.10.49
+boto3>=1.10.49
 envs~=1.3
 python-jose[pycryptodome]~=3.1.0
-requests~=2.22.0
+requests>=2.22.0
 six>=1.13.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
-mock>=2.0.0
-nose
-coverage
+botocore~=1.13.49
+coverage~=5.0.2
+mock~=3.0.5
+nose~=1.3.7

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,19 @@
 import os
+import re
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
 
-install_reqs = parse_requirements('requirements.txt', session=False)
-test_reqs = parse_requirements('requirements_test.txt', session=False)
+
+def requirements_from_file(filename='requirements.txt'):
+    with open(os.path.join(os.path.dirname(__file__), filename)) as r:
+        reqs = r.read().strip().split('\n')
+    # Return non emtpy lines and non comments
+    return [r for r in reqs if re.match(r"^\w+", r)]
+
 
 version = '0.6.1'
 
-README="""Python class to integrate Boto3's Cognito client so it is easy to login users. With SRP support."""
+README = """Python class to integrate Boto3's Cognito client so it is easy to login users. With SRP support."""
 
 setup(
     name='warrant',
@@ -16,8 +21,9 @@ setup(
     description=README,
     long_description=README,
     classifiers=[
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Environment :: Web Environment",
     ],
@@ -28,11 +34,10 @@ setup(
     packages=find_packages(),
     url='https://github.com/capless/warrant',
     license='Apache License 2.0',
-    install_requires=[str(ir.req) for ir in install_reqs],
+    install_requires=requirements_from_file(),
     extras_require={
-        'test': [str(ir.req) for ir in test_reqs]
+        'dev': requirements_from_file('requirements_test.txt')
     },
     include_package_data=True,
     zip_safe=True,
-
 )

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -177,9 +177,9 @@ class Cognito(object):
 
     def get_keys(self):
 
-        try:
+        if self.pool_jwk:
             return self.pool_jwk
-        except AttributeError:
+        else:
             # Check for the dictionary in environment variables.
             pool_jwk_env = env('COGNITO_JWKS', {}, var_type='dict')
             if len(pool_jwk_env.keys()) > 0:

--- a/warrant/__init__.py
+++ b/warrant/__init__.py
@@ -20,22 +20,25 @@ def cognito_to_dict(attr_list, attr_map=None):
         value = a.get('Value')
         if value in ['true', 'false']:
             value = ast.literal_eval(value.capitalize())
-        name = attr_map.get(name,name)
+        name = attr_map.get(name, name)
         attr_dict[name] = value
     return attr_dict
+
 
 def dict_to_cognito(attributes, attr_map=None):
     """
     :param attributes: Dictionary of User Pool attribute names/values
+    :param attr_map: Dictonnary with attributes mapping
     :return: list of User Pool attribute formatted dicts: {'Name': <attr_name>, 'Value': <attr_value>}
     """
     if attr_map is None:
         attr_map = {}
-    for k,v in attr_map.items():
+    for k, v in attr_map.items():
         if v in attributes.keys():
             attributes[k] = attributes.pop(v)
 
     return [{'Name': key, 'Value': value} for key, value in attributes.items()]
+
 
 def camel_to_snake(camel_str):
     """
@@ -44,6 +47,7 @@ def camel_to_snake(camel_str):
     """
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', camel_str)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
 
 def snake_to_camel(snake_str):
     """
@@ -66,10 +70,10 @@ class UserObj(object):
         self.pk = username
         self._cognito = cognito_obj
         self._attr_map = {} if attr_map is None else attr_map
-        self._data = cognito_to_dict(attribute_list,self._attr_map)
-        self.sub = self._data.pop('sub',None)
-        self.email_verified = self._data.pop('email_verified',None)
-        self.phone_number_verified = self._data.pop('phone_number_verified',None)
+        self._data = cognito_to_dict(attribute_list, self._attr_map)
+        self.sub = self._data.pop('sub', None)
+        self.email_verified = self._data.pop('email_verified', None)
+        self.phone_number_verified = self._data.pop('phone_number_verified', None)
         self._metadata = {} if metadata is None else metadata
 
     def __repr__(self):
@@ -80,24 +84,24 @@ class UserObj(object):
         return self.username
 
     def __getattr__(self, name):
-        if name in list(self.__dict__.get('_data',{}).keys()):
+        if name in list(self.__dict__.get('_data', {}).keys()):
             return self._data.get(name)
-        if name in list(self.__dict__.get('_metadata',{}).keys()):
+        if name in list(self.__dict__.get('_metadata', {}).keys()):
             return self._metadata.get(name)
 
     def __setattr__(self, name, value):
-        if name in list(self.__dict__.get('_data',{}).keys()):
+        if name in list(self.__dict__.get('_data', {}).keys()):
             self._data[name] = value
         else:
             super(UserObj, self).__setattr__(name, value)
 
-    def save(self,admin=False):
+    def save(self, admin=False):
         if admin:
             self._cognito.admin_update_profile(self._data, self._attr_map)
             return
-        self._cognito.update_profile(self._data,self._attr_map)
+        self._cognito.update_profile(self._data, self._attr_map)
 
-    def delete(self,admin=False):
+    def delete(self, admin=False):
         if admin:
             self._cognito.admin_delete_user()
             return
@@ -129,16 +133,15 @@ class GroupObj(object):
 
 
 class Cognito(object):
-
     user_class = UserObj
     group_class = GroupObj
 
     def __init__(
-            self, user_pool_id, client_id,user_pool_region=None,
+            self, user_pool_id, client_id, user_pool_region=None,
             username=None, id_token=None, refresh_token=None,
             access_token=None, client_secret=None,
             access_key=None, secret_key=None,
-            ):
+    ):
         """
         :param user_pool_id: Cognito User Pool ID
         :param client_id: Cognito User Pool Application client ID
@@ -152,7 +155,7 @@ class Cognito(object):
 
         self.user_pool_id = user_pool_id
         self.client_id = client_id
-        self.user_pool_region = self.user_pool_id.split('_')[0]
+        self.user_pool_region = user_pool_region if user_pool_region else self.user_pool_id.split('_')[0]
         self.username = username
         self.id_token = id_token
         self.access_token = access_token
@@ -161,13 +164,14 @@ class Cognito(object):
         self.token_type = None
         self.custom_attributes = None
         self.base_attributes = None
+        self.pool_jwk = None
 
         boto3_client_kwargs = {}
         if access_key and secret_key:
             boto3_client_kwargs['aws_access_key_id'] = access_key
             boto3_client_kwargs['aws_secret_access_key'] = secret_key
-        if user_pool_region:
-            boto3_client_kwargs['region_name'] = user_pool_region
+        if self.user_pool_region:
+            boto3_client_kwargs['region_name'] = self.user_pool_region
 
         self.client = boto3.client('cognito-idp', **boto3_client_kwargs)
 
@@ -176,24 +180,24 @@ class Cognito(object):
         try:
             return self.pool_jwk
         except AttributeError:
-            #Check for the dictionary in environment variables.
-            pool_jwk_env = env('COGNITO_JWKS', {},var_type='dict')
+            # Check for the dictionary in environment variables.
+            pool_jwk_env = env('COGNITO_JWKS', {}, var_type='dict')
             if len(pool_jwk_env.keys()) > 0:
                 self.pool_jwk = pool_jwk_env
                 return self.pool_jwk
-            #If it is not there use the requests library to get it
+            # If it is not there use the requests library to get it
             self.pool_jwk = requests.get(
                 'https://cognito-idp.{}.amazonaws.com/{}/.well-known/jwks.json'.format(
-                    self.user_pool_region,self.user_pool_id
+                    self.user_pool_region, self.user_pool_id
                 )).json()
             return self.pool_jwk
 
-    def get_key(self,kid):
+    def get_key(self, kid):
         keys = self.get_keys().get('keys')
-        key = list(filter(lambda x:x.get('kid') == kid,keys))
+        key = list(filter(lambda x: x.get('kid') == kid, keys))
         return key[0]
 
-    def verify_token(self,token,id_name,token_use):
+    def verify_token(self, token, id_name, token_use):
         kid = jwt.get_unverified_header(token).get('kid')
         unverified_claims = jwt.get_unverified_claims(token)
         token_use_verified = unverified_claims.get('token_use') == token_use
@@ -201,12 +205,12 @@ class Cognito(object):
             raise TokenVerificationException('Your {} token use could not be verified.')
         hmac_key = self.get_key(kid)
         try:
-            verified = jwt.decode(token,hmac_key,algorithms=['RS256'],
-                   audience=unverified_claims.get('aud'),
-                   issuer=unverified_claims.get('iss'))
+            verified = jwt.decode(token, hmac_key, algorithms=['RS256'],
+                                  audience=unverified_claims.get('aud'),
+                                  issuer=unverified_claims.get('iss'))
         except JWTError:
             raise TokenVerificationException('Your {} token could not be verified.')
-        setattr(self,id_name,token)
+        setattr(self, id_name, token)
         return verified
 
     def get_user_obj(self, username=None, attribute_list=None, metadata=None,
@@ -221,9 +225,9 @@ class Cognito(object):
         what we'd like to display to the users
         :return:
         """
-        return self.user_class(username=username,attribute_list=attribute_list,
+        return self.user_class(username=username, attribute_list=attribute_list,
                                cognito_obj=self,
-                               metadata=metadata,attr_map=attr_map)
+                               metadata=metadata, attr_map=attr_map)
 
     def get_group_obj(self, group_data):
         """
@@ -233,7 +237,7 @@ class Cognito(object):
         """
         return self.group_class(group_data=group_data, cognito_obj=self)
 
-    def switch_session(self,session):
+    def switch_session(self, session):
         """
         Primarily used for unit testing so we can take advantage of the
         placebo library (https://githhub.com/garnaat/placebo)
@@ -268,11 +272,11 @@ class Cognito(object):
     def add_custom_attributes(self, **kwargs):
         custom_key = 'custom'
         custom_attributes = {}
-        
+
         for old_key, value in kwargs.items():
             new_key = custom_key + ':' + old_key
             custom_attributes[new_key] = value
-        
+
         self.custom_attributes = custom_attributes
 
     def register(self, username, password, attr_map=None):
@@ -330,7 +334,7 @@ class Cognito(object):
             Username=username,
         )
 
-    def confirm_sign_up(self,confirmation_code,username=None):
+    def confirm_sign_up(self, confirmation_code, username=None):
         """
         Using the confirmation code that is either sent via email or text
         message.
@@ -353,9 +357,9 @@ class Cognito(object):
         :return:
         """
         auth_params = {
-                'USERNAME': self.username,
-                'PASSWORD': password
-            }
+            'USERNAME': self.username,
+            'PASSWORD': password
+        }
         self._add_secret_hash(auth_params, 'SECRET_HASH')
         tokens = self.client.admin_initiate_auth(
             UserPoolId=self.user_pool_id,
@@ -365,9 +369,9 @@ class Cognito(object):
             AuthParameters=auth_params,
         )
 
-        self.verify_token(tokens['AuthenticationResult']['IdToken'], 'id_token','id')
+        self.verify_token(tokens['AuthenticationResult']['IdToken'], 'id_token', 'id')
         self.refresh_token = tokens['AuthenticationResult']['RefreshToken']
-        self.verify_token(tokens['AuthenticationResult']['AccessToken'], 'access_token','access')
+        self.verify_token(tokens['AuthenticationResult']['AccessToken'], 'access_token', 'access')
         self.token_type = tokens['AuthenticationResult']['TokenType']
 
     def authenticate(self, password):
@@ -380,16 +384,16 @@ class Cognito(object):
                      client_id=self.client_id, client=self.client,
                      client_secret=self.client_secret)
         tokens = aws.authenticate_user()
-        self.verify_token(tokens['AuthenticationResult']['IdToken'],'id_token','id')
+        self.verify_token(tokens['AuthenticationResult']['IdToken'], 'id_token', 'id')
         self.refresh_token = tokens['AuthenticationResult']['RefreshToken']
-        self.verify_token(tokens['AuthenticationResult']['AccessToken'], 'access_token','access')
+        self.verify_token(tokens['AuthenticationResult']['AccessToken'], 'access_token', 'access')
         self.token_type = tokens['AuthenticationResult']['TokenType']
 
     def new_password_challenge(self, password, new_password):
         """
         Respond to the new password challenge using the SRP protocol
         :param password: The user's current passsword
-        :param password: The user's new passsword
+        :param new_password: The user's new passsword
         """
         aws = AWSSRP(username=self.username, password=password, pool_id=self.user_pool_id,
                      client_id=self.client_id, client=self.client,
@@ -419,9 +423,9 @@ class Cognito(object):
     def admin_update_profile(self, attrs, attr_map=None):
         user_attrs = dict_to_cognito(attrs, attr_map)
         self.client.admin_update_user_attributes(
-            UserPoolId = self.user_pool_id,
-            Username = self.username,
-            UserAttributes = user_attrs
+            UserPoolId=self.user_pool_id,
+            Username=self.username,
+            UserAttributes=user_attrs
         )
 
     def update_profile(self, attrs, attr_map=None):
@@ -431,7 +435,7 @@ class Cognito(object):
         :param attr_map: Dictionary map from Cognito attributes to attribute
         names we would like to show to our users
         """
-        user_attrs = dict_to_cognito(attrs,attr_map)
+        user_attrs = dict_to_cognito(attrs, attr_map)
         self.client.update_user_attributes(
             UserAttributes=user_attrs,
             AccessToken=self.access_token
@@ -446,8 +450,8 @@ class Cognito(object):
         :return:
         """
         user = self.client.get_user(
-                AccessToken=self.access_token
-            )
+            AccessToken=self.access_token
+        )
 
         user_metadata = {
             'username': user.get('Username'),
@@ -457,7 +461,7 @@ class Cognito(object):
         }
         return self.get_user_obj(username=self.username,
                                  attribute_list=user.get('UserAttributes'),
-                                 metadata=user_metadata,attr_map=attr_map)
+                                 metadata=user_metadata, attr_map=attr_map)
 
     def get_users(self, attr_map=None):
         """
@@ -466,12 +470,12 @@ class Cognito(object):
         :param attr_map:
         :return:
         """
-        kwargs = {"UserPoolId":self.user_pool_id}
+        kwargs = {"UserPoolId": self.user_pool_id}
 
         response = self.client.list_users(**kwargs)
         return [self.get_user_obj(user.get('Username'),
                                   attribute_list=user.get('Attributes'),
-                                  metadata={'username':user.get('Username')},
+                                  metadata={'username': user.get('Username')},
                                   attr_map=attr_map)
                 for user in response.get('Users')]
 
@@ -483,19 +487,19 @@ class Cognito(object):
         :return: UserObj object
         """
         user = self.client.admin_get_user(
-                           UserPoolId=self.user_pool_id,
-                           Username=self.username)
+            UserPoolId=self.user_pool_id,
+            Username=self.username)
         user_metadata = {
             'enabled': user.get('Enabled'),
-            'user_status':user.get('UserStatus'),
-            'username':user.get('Username'),
+            'user_status': user.get('UserStatus'),
+            'username': user.get('Username'),
             'id_token': self.id_token,
             'access_token': self.access_token,
             'refresh_token': self.refresh_token
         }
         return self.get_user_obj(username=self.username,
                                  attribute_list=user.get('UserAttributes'),
-                                 metadata=user_metadata,attr_map=attr_map)
+                                 metadata=user_metadata, attr_map=attr_map)
 
     def admin_create_user(self, username, temporary_password='', attr_map=None, **kwargs):
         """
@@ -575,13 +579,11 @@ class Cognito(object):
         self._add_secret_hash(params, 'SecretHash')
         self.client.forgot_password(**params)
 
-
     def delete_user(self):
 
         self.client.delete_user(
             AccessToken=self.access_token
         )
-
 
     def admin_delete_user(self):
         self.client.admin_delete_user(
@@ -661,4 +663,3 @@ class Cognito(object):
         response = self.client.list_groups(UserPoolId=self.user_pool_id)
         return [self.get_group_obj(group_data)
                 for group_data in response.get('Groups')]
-

--- a/warrant/aws_srp.py
+++ b/warrant/aws_srp.py
@@ -163,7 +163,7 @@ class AWSSRP(object):
         if self.client_secret is not None:
             auth_params.update({
                 "SECRET_HASH":
-                self.get_secret_hash(self.username,self.client_id, self.client_secret)})
+                self.get_secret_hash(self.username, self.client_id, self.client_secret)})
         return auth_params
 
     @staticmethod
@@ -184,7 +184,7 @@ class AWSSRP(object):
                                                     self.password, hex_to_long(srp_b_hex), salt_hex)
         secret_block_bytes = base64.standard_b64decode(secret_block_b64)
         msg = bytearray(self.pool_id.split('_')[1], 'utf-8') + bytearray(user_id_for_srp, 'utf-8') + \
-              bytearray(secret_block_bytes) + bytearray(timestamp, 'utf-8')
+            bytearray(secret_block_bytes) + bytearray(timestamp, 'utf-8')
         hmac_obj = hmac.new(hkdf, msg, digestmod=hashlib.sha256)
         signature_string = base64.standard_b64encode(hmac_obj.digest())
         response = {'TIMESTAMP': timestamp,

--- a/warrant/tests/tests.py
+++ b/warrant/tests/tests.py
@@ -1,24 +1,49 @@
 import unittest
 
-from mock import patch
+from botocore.exceptions import ParamValidationError
+from botocore.stub import Stubber
 from envs import env
+from mock import patch
 
 from warrant import Cognito, UserObj, GroupObj, TokenVerificationException
 from warrant.aws_srp import AWSSRP
 
 
+def _mock_authenticate_user(_, client=None):
+    return {
+        'AuthenticationResult': {
+            'TokenType': 'admin',
+            'IdToken': 'dummy_token',
+            'AccessToken': 'dummy_token',
+            'RefreshToken': 'dummy_token'
+        }
+    }
+
+
+def _mock_get_params(_):
+    return {'USERNAME': 'bob', 'SRP_A': 'srp'}
+
+
+def _mock_verify_tokens(self, token, id_name, token_use):
+    if 'wrong' in token:
+        raise TokenVerificationException
+    setattr(self, id_name, token)
+
+
 class UserObjTestCase(unittest.TestCase):
 
     def setUp(self):
-        if env('USE_CLIENT_SECRET') == 'True':
+        if env('USE_CLIENT_SECRET', 'False') == 'True':
             self.app_id = env('COGNITO_APP_WITH_SECRET_ID')
         else:
             self.app_id = env('COGNITO_APP_ID')
-        self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID')
+        self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID', 'us-east-1_123456789')
         self.username = env('COGNITO_TEST_USERNAME')
 
-        self.user = Cognito(self.cognito_user_pool_id, self.app_id,
-                            self.username)
+        self.user = Cognito(user_pool_id=self.cognito_user_pool_id,
+                            client_id=self.app_id,
+                            username=self.username)
+
         self.user_metadata = {
             'user_status': 'CONFIRMED',
             'username': 'bjones',
@@ -31,21 +56,22 @@ class UserObjTestCase(unittest.TestCase):
 
     def test_init(self):
         u = UserObj('bjones', self.user_info, self.user, self.user_metadata)
-        self.assertEqual(u.pk,self.user_metadata.get('username'))
-        self.assertEqual(u.name,self.user_info[0].get('Value'))
-        self.assertEqual(u.user_status,self.user_metadata.get('user_status'))
+        self.assertEqual(u.pk, self.user_metadata.get('username'))
+        self.assertEqual(u.name, self.user_info[0].get('Value'))
+        self.assertEqual(u.user_status, self.user_metadata.get('user_status'))
 
 
 class GroupObjTestCase(unittest.TestCase):
 
     def setUp(self):
-        if env('USE_CLIENT_SECRET') == 'True':
+        if env('USE_CLIENT_SECRET', 'False') == 'True':
             self.app_id = env('COGNITO_APP_WITH_SECRET_ID')
         else:
             self.app_id = env('COGNITO_APP_ID')
-        self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID')
+        self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID', 'us-east-1_123456789')
         self.group_data = {'GroupName': 'test_group', 'Precedence': 1}
-        self.cognito_obj = Cognito(self.cognito_user_pool_id, self.app_id)
+        self.cognito_obj = Cognito(user_pool_id=self.cognito_user_pool_id,
+                                   client_id=self.app_id)
 
     def test_init(self):
         group = GroupObj(group_data=self.group_data, cognito_obj=self.cognito_obj)
@@ -57,29 +83,34 @@ class CognitoAuthTestCase(unittest.TestCase):
 
     def setUp(self):
         if env('USE_CLIENT_SECRET') == 'True':
-            self.app_id = env('COGNITO_APP_WITH_SECRET_ID')
+            self.app_id = env('COGNITO_APP_WITH_SECRET_ID', 'app')
             self.client_secret = env('COGNITO_CLIENT_SECRET')
         else:
-            self.app_id = env('COGNITO_APP_ID')
+            self.app_id = env('COGNITO_APP_ID', 'app')
             self.client_secret = None
-        self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID')
-        self.username = env('COGNITO_TEST_USERNAME')
-        self.password = env('COGNITO_TEST_PASSWORD')
-        self.user = Cognito(self.cognito_user_pool_id,self.app_id,
-                         username=self.username, client_secret=self.client_secret)
+        self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID', 'us-east-1_123456789')
+        self.username = env('COGNITO_TEST_USERNAME', 'bob')
+        self.password = env('COGNITO_TEST_PASSWORD', 'bobpassword')
+        self.user = Cognito(self.cognito_user_pool_id, self.app_id,
+                            username=self.username,
+                            client_secret=self.client_secret)
 
-
+    @patch('warrant.aws_srp.AWSSRP.authenticate_user', _mock_authenticate_user)
+    @patch('warrant.Cognito.verify_token', _mock_verify_tokens)
     def test_authenticate(self):
+
         self.user.authenticate(self.password)
-        self.assertNotEqual(self.user.access_token,None)
+        self.assertNotEqual(self.user.access_token, None)
         self.assertNotEqual(self.user.id_token, None)
         self.assertNotEqual(self.user.refresh_token, None)
 
+    @patch('warrant.aws_srp.AWSSRP.authenticate_user', _mock_authenticate_user)
+    @patch('warrant.Cognito.verify_token', _mock_verify_tokens)
     def test_verify_token(self):
         self.user.authenticate(self.password)
         bad_access_token = '{}wrong'.format(self.user.access_token)
 
-        with self.assertRaises(TokenVerificationException) as vm:
+        with self.assertRaises(TokenVerificationException):
             self.user.verify_token(bad_access_token, 'access_token', 'access')
 
     # def test_logout(self):
@@ -98,76 +129,162 @@ class CognitoAuthTestCase(unittest.TestCase):
             name='Brian Jones', email='bjones39@capless.io',
             phone_number='+19194894555', gender='Male',
             preferred_username='billyocean')
-        res = u.register('sampleuser', 'sample4#Password')
+        u.register('sampleuser', 'sample4#Password')
 
-        #TODO: Write assumptions
+        # TODO: Write assumptions
 
+    @patch('warrant.aws_srp.AWSSRP.authenticate_user', _mock_authenticate_user)
+    @patch('warrant.Cognito.verify_token', _mock_verify_tokens)
+    @patch('warrant.Cognito._add_secret_hash', return_value=None)
+    def test_renew_tokens(self, _):
 
-    def test_renew_tokens(self):
-        self.user.authenticate(self.password)
-        self.user.renew_access_token()
+        stub = Stubber(self.user.client)
+
+        # By the stubber nature, we need to add the sequence
+        # of calls for the AWS SRP auth to test the whole process
+        stub.add_response(method='initiate_auth',
+                          service_response={
+                              'AuthenticationResult': {
+                                  'TokenType': 'admin',
+                                  'IdToken': 'dummy_token',
+                                  'AccessToken': 'dummy_token',
+                                  'RefreshToken': 'dummy_token'
+                              },
+                              'ResponseMetadata': {'HTTPStatusCode': 200}
+                          },
+                          expected_params={
+                              'ClientId': self.app_id,
+                              'AuthFlow': 'REFRESH_TOKEN',
+                              'AuthParameters': {'REFRESH_TOKEN': 'dummy_token'}
+                          })
+
+        with stub:
+            self.user.authenticate(self.password)
+            self.user.renew_access_token()
+            stub.assert_no_pending_responses()
 
     @patch('warrant.Cognito', autospec=True)
-    def test_update_profile(self,cognito_user):
+    def test_update_profile(self, cognito_user):
         u = cognito_user(self.cognito_user_pool_id, self.app_id,
                          username=self.username)
         u.authenticate(self.password)
-        u.update_profile({'given_name':'Jenkins'})
-
+        u.update_profile({'given_name': 'Jenkins'})
 
     def test_admin_get_user(self):
-        u = self.user.admin_get_user()
-        self.assertEqual(u.pk,self.username)
+
+        stub = Stubber(self.user.client)
+
+        stub.add_response(method='admin_get_user',
+                          service_response={
+                              'Enabled': True,
+                              'UserStatus': 'CONFIRMED',
+                              'Username': self.username,
+                              'UserAttributes': []
+                          },
+                          expected_params={
+                              'UserPoolId': self.cognito_user_pool_id,
+                              'Username': self.username
+                          })
+
+        with stub:
+            u = self.user.admin_get_user()
+            self.assertEqual(u.pk, self.username)
+            stub.assert_no_pending_responses()
 
     def test_check_token(self):
-        self.user.authenticate(self.password)
+        # This is a sample JWT with an expiration time set to January, 1st, 3000
+        self.user.access_token = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG'
+                                  '9lIiwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjMyNTAzNjgwMDAwfQ.C-1gPxrhUsiWeCvMvaZuuQYarkDNAc'
+                                  'pEGJPIqu_SrKQ')
         self.assertFalse(self.user.check_token())
 
-
     @patch('warrant.Cognito', autospec=True)
-    def test_validate_verification(self,cognito_user):
-        u = cognito_user(self.cognito_user_pool_id,self.app_id,
-                     username=self.username)
+    def test_validate_verification(self, cognito_user):
+        u = cognito_user(self.cognito_user_pool_id, self.app_id,
+                         username=self.username)
         u.validate_verification('4321')
 
     @patch('warrant.Cognito', autospec=True)
-    def test_confirm_forgot_password(self,cognito_user):
+    def test_confirm_forgot_password(self, cognito_user):
         u = cognito_user(self.cognito_user_pool_id, self.app_id,
                          username=self.username)
-        u.confirm_forgot_password('4553','samplepassword')
-        with self.assertRaises(TypeError) as vm:
+        u.confirm_forgot_password('4553', 'samplepassword')
+        with self.assertRaises(TypeError):
             u.confirm_forgot_password(self.password)
 
-    @patch('warrant.Cognito', autospec=True)
-    def test_change_password(self,cognito_user):
-        u = cognito_user(self.cognito_user_pool_id, self.app_id,
-                         username=self.username)
-        u.authenticate(self.password)
-        u.change_password(self.password,'crazypassword$45DOG')
+    @patch('warrant.aws_srp.AWSSRP.authenticate_user', _mock_authenticate_user)
+    @patch('warrant.Cognito.verify_token', _mock_verify_tokens)
+    @patch('warrant.Cognito.check_token', return_value=True)
+    def test_change_password(self, _):
+        # u = cognito_user(self.cognito_user_pool_id, self.app_id,
+        #                  username=self.username)
+        self.user.authenticate(self.password)
 
-        with self.assertRaises(TypeError) as vm:
-            self.user.change_password(self.password)
+        stub = Stubber(self.user.client)
+
+        stub.add_response(method='change_password',
+                          service_response={
+                              'ResponseMetadata': {'HTTPStatusCode': 200}
+                          },
+                          expected_params={
+                              'PreviousPassword': self.password,
+                              'ProposedPassword': 'crazypassword$45DOG',
+                              'AccessToken': self.user.access_token
+                          })
+
+        with stub:
+            self.user.change_password(self.password, 'crazypassword$45DOG')
+            stub.assert_no_pending_responses()
+
+        with self.assertRaises(ParamValidationError):
+            self.user.change_password(self.password, None)
 
     def test_set_attributes(self):
-        u = Cognito(self.cognito_user_pool_id,self.app_id)
+        u = Cognito(self.cognito_user_pool_id, self.app_id)
         u._set_attributes({
-                'ResponseMetadata':{
-                    'HTTPStatusCode':200
-                }
+            'ResponseMetadata': {
+                'HTTPStatusCode': 200
+            }
         },
             {
-                'somerandom':'attribute'
+                'somerandom': 'attribute'
             }
         )
-        self.assertEqual(u.somerandom,'attribute')
+        self.assertEqual(u.somerandom, 'attribute')
 
-    
+    #
+
+    @patch('warrant.Cognito.verify_token', _mock_verify_tokens)
     def test_admin_authenticate(self):
-        
-        self.user.admin_authenticate(self.password)
-        self.assertNotEqual(self.user.access_token,None)
-        self.assertNotEqual(self.user.id_token, None)
-        self.assertNotEqual(self.user.refresh_token, None)
+
+        stub = Stubber(self.user.client)
+
+        # By the stubber nature, we need to add the sequence
+        # of calls for the AWS SRP auth to test the whole process
+        stub.add_response(method='admin_initiate_auth',
+                          service_response={
+                              'AuthenticationResult': {
+                                  'TokenType': 'admin',
+                                  'IdToken': 'dummy_token',
+                                  'AccessToken': 'dummy_token',
+                                  'RefreshToken': 'dummy_token'
+                              }
+                          },
+                          expected_params={
+                              'UserPoolId': self.cognito_user_pool_id,
+                              'ClientId': self.app_id,
+                              'AuthFlow': 'ADMIN_NO_SRP_AUTH',
+                              'AuthParameters': {
+                                  'USERNAME': self.username,
+                                  'PASSWORD': self.password}
+                          })
+
+        with stub:
+            self.user.admin_authenticate(self.password)
+            self.assertNotEqual(self.user.access_token, None)
+            self.assertNotEqual(self.user.id_token, None)
+            self.assertNotEqual(self.user.refresh_token, None)
+            stub.assert_no_pending_responses()
 
 
 class AWSSRPTestCase(unittest.TestCase):
@@ -175,25 +292,62 @@ class AWSSRPTestCase(unittest.TestCase):
     def setUp(self):
         if env('USE_CLIENT_SECRET') == 'True':
             self.client_secret = env('COGNITO_CLIENT_SECRET')
-            self.app_id = env('COGNITO_APP_WITH_SECRET_ID')
+            self.app_id = env('COGNITO_APP_WITH_SECRET_ID', 'app')
         else:
-            self.app_id = env('COGNITO_APP_ID')
+            self.app_id = env('COGNITO_APP_ID', 'app')
             self.client_secret = None
-        self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID')
+        self.cognito_user_pool_id = env('COGNITO_USER_POOL_ID', 'us-east-1_123456789')
         self.username = env('COGNITO_TEST_USERNAME')
         self.password = env('COGNITO_TEST_PASSWORD')
-        self.aws = AWSSRP(username=self.username, password=self.password,
+        self.aws = AWSSRP(username=self.username,
+                          password=self.password,
+                          pool_region='us-east-1',
                           pool_id=self.cognito_user_pool_id,
-                          client_id=self.app_id, client_secret=self.client_secret)
+                          client_id=self.app_id,
+                          client_secret=self.client_secret)
 
     def tearDown(self):
         del self.aws
 
-    def test_authenticate_user(self):
-        tokens = self.aws.authenticate_user()
-        self.assertTrue('IdToken' in tokens['AuthenticationResult'])
-        self.assertTrue('AccessToken' in tokens['AuthenticationResult'])
-        self.assertTrue('RefreshToken' in tokens['AuthenticationResult'])
+    @patch('warrant.aws_srp.AWSSRP.get_auth_params', _mock_get_params)
+    @patch('warrant.aws_srp.AWSSRP.process_challenge', return_value={})
+    def test_authenticate_user(self, _):
+
+        stub = Stubber(self.aws.client)
+
+        # By the stubber nature, we need to add the sequence
+        # of calls for the AWS SRP auth to test the whole process
+        stub.add_response(method='initiate_auth',
+                          service_response={
+                              'ChallengeName': 'PASSWORD_VERIFIER',
+                              'ChallengeParameters': {}
+                          },
+                          expected_params={
+                              'AuthFlow': 'USER_SRP_AUTH',
+                              'AuthParameters': _mock_get_params(None),
+                              'ClientId': self.app_id
+                          })
+
+        stub.add_response(method='respond_to_auth_challenge',
+                          service_response={
+                              'AuthenticationResult': {
+                                  'IdToken': 'dummy_token',
+                                  'AccessToken': 'dummy_token',
+                                  'RefreshToken': 'dummy_token'
+                              }
+                          },
+                          expected_params={
+                              'ClientId': self.app_id,
+                              'ChallengeName': 'PASSWORD_VERIFIER',
+                              'ChallengeResponses': {}
+                          })
+
+        with stub:
+            tokens = self.aws.authenticate_user()
+            self.assertTrue('IdToken' in tokens['AuthenticationResult'])
+            self.assertTrue('AccessToken' in tokens['AuthenticationResult'])
+            self.assertTrue('RefreshToken' in tokens['AuthenticationResult'])
+            stub.assert_no_pending_responses()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR brings a couple of changes:

- drop support of python-jose-cryptodome in favor of python-jose[cryptodome]
- add support for local unit tests (from @kritchie)
- some cleanup
