### PR TITLE
Upgrade python-jose dependency to fix ImportError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3>=1.10.49
 envs~=1.3
-python-jose[pycryptodome]~=3.1.0
+python-jose[pycryptodome]~=3.3.0
 requests>=2.22.0
 six>=1.13.0


### PR DESCRIPTION
ImportError: cannot import name 'Mapping' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)

should be fixed with python-jose==3.3.0

ImportError verified in Python 3.10 (probably also in 3.9)